### PR TITLE
Only compile jo, not documentation

### DIFF
--- a/jo.rb
+++ b/jo.rb
@@ -4,7 +4,7 @@ class Jo < Formula
   head "https://github.com/jpmens/jo.git"
 
   def install
-    system "make", "jo", "jo.1"
+    system "make", "jo"
 
     bin.install "jo"
     man1.install "jo.1"


### PR DESCRIPTION
That's already up to date in the upstream repo, so we can just install that without having to compile it. Removes the dependency on pandoc (not that I documented that, oops!)

Closes #1